### PR TITLE
Expand error response while raising APIStatusError

### DIFF
--- a/chibi/utils.py
+++ b/chibi/utils.py
@@ -229,7 +229,7 @@ def handle_gpt_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
             return None
 
         except APIStatusError as e:
-            logger.error(f"{user_data(update)} got a status code {e.status_code} response: {e.response}")
+            logger.error(f"{user_data(update)} got a status code {e.status_code} response: {e.response.text}")
             await send_message(
                 update=update,
                 context=context,


### PR DESCRIPTION
After switching model type I received an error, but don't know the reason:
<img width="990" alt="~:bots:chibi:chibi 2024-05-10 19-45-28" src="https://github.com/s-nagaev/chibi/assets/11560975/7179ffbf-7651-4512-91b7-cc7e0bbdde6f">

The small fix in this pull request expands error, so now I understand what happens:
<img width="976" alt="~:bots:chibi:chibi 2024-05-10 19-45-28_nice" src="https://github.com/s-nagaev/chibi/assets/11560975/a119f681-5a5e-4e29-93e2-bb1e552aedb0">
