### PR TITLE
Fix loading anthropic messages with tools usage.

### DIFF
--- a/chibi/services/providers/provider.py
+++ b/chibi/services/providers/provider.py
@@ -623,7 +623,13 @@ class AnthropicFriendlyProvider(RestApiFriendlyProvider):
         context: ContextTypes.DEFAULT_TYPE | None = None,
     ) -> tuple[ChatResponseSchema, list[Message]]:
         model = model or self.default_model
-        initial_messages = [msg.to_anthropic() for msg in messages]
+        initial_messages = []
+        anthropic_msg: MessageParam | None = None
+        for idx, msg in enumerate(messages):
+            if msg.role == "tool" and anthropic_msg and anthropic_msg["role"] == "assistant":
+                msg.tool_call_id = anthropic_msg["content"][1]["id"]  # type: ignore
+            anthropic_msg = msg.to_anthropic()
+            initial_messages.append(anthropic_msg)
 
         if len(initial_messages) >= 2:
             initial_messages[-2]["content"][0]["cache_control"] = {"type": "ephemeral"}  # type: ignore


### PR DESCRIPTION
## Fixed loading of Anthropic messages with tool usage.


## Issue
It was not possible to switch from another provider to Anthropic and back without losing the tool usage context.
This happened due to differences in message content formats between Anthropic and other providers.