### PR TITLE
Fix: Prevent agent image from overwriting latest Docker tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           images: |
             ${{ matrix.image_name }}
+          flavor: |
+            latest=${{ matrix.tag_prefix == '' }}
           tags: |
             type=schedule,prefix=${{ matrix.tag_prefix }}
             type=ref,event=branch,prefix=${{ matrix.tag_prefix }}

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+## [1.7.2] - 2026-03-10
+
+### Fixed
+- **Docker Image Tagging:** Fixed GitHub Actions workflow where agent Docker image was incorrectly overwriting 
+the `latest` tag. The `latest` tag is now correctly assigned only to the regular image, while agent image receives only `agent-*` prefixed tags.
+
 ## [1.7.1] - 2026-03-10
 
 ### Added
@@ -479,7 +485,8 @@ applied.
 - Flake8 and Mypy setups.
 - GitHub Action for linters.
 
-[Unreleased]: https://github.com/s-nagaev/chibi/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/s-nagaev/chibi/compare/v1.7.2...HEAD
+[1.7.2]: https://github.com/s-nagaev/chibi/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/s-nagaev/chibi/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/s-nagaev/chibi/compare/v1.6.6...v1.7.0
 [1.6.6]: https://github.com/s-nagaev/chibi/compare/v1.6.5...v1.6.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chibi-bot"
-version = "1.7.1"
+version = "1.7.2"
 description = "Your Digital Companion. Self-hosted Telegram bot orchestrating multiple AI providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Alibaba, MiniMax) with autonomous agent capabilities, MCP integrations, and async task execution. Not a tool. A partner."
 authors = ["Sergei Nagaev <nagaev.sv@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

The GitHub Actions workflow was incorrectly generating the `latest` tag for both regular and agent Docker images. When the agent build finished last, it would overwrite the regular image's `latest` tag on Docker Hub.

This caused users pulling `pysergio/chibi:latest` to receive the agent image instead of the regular one, which includes unintended environment variables like `FILESYSTEM_ACCESS=true`.

## Solution

Added `flavor` configuration to `docker/metadata-action` to only enable the `latest` tag when `tag_prefix` is empty (i.e., for the regular image):

```yaml
flavor: |
  latest=${{ matrix.tag_prefix == '' }}
```

## Changes

- `.github/workflows/build.yml`: Added flavor configuration to control latest tag generation
- `changelog.md`: Added entry for version 1.7.2

## Testing

After this fix:
- `pysergio/chibi:latest` → Regular image (non-root user, no agent-specific env vars)
- `pysergio/chibi:agent-latest` → Agent image (root user, with MCP tools and filesystem access)

Fixes Docker image tagging conflict between regular and agent builds.
