### PR TITLE
Feat: Groups and Roles support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Chibi supports multiple providers behind a single conversation. Add one key or m
 - **Moonshot AI**
 - **MiniMax**
 - **ZhipuAI** (GLM models)
+- **OpenRouter** (unified access to many models)
 - **Cloudflare Workers AI** (many open-source models)
 
 ### OpenAI-compatible endpoints (self-host / local)
@@ -162,6 +163,7 @@ Each provider requires its own API key. Here are the direct links:
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (unified access to many models): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **Creative Tools:**

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-06-07
+
+### Added
+- **Custom agent role/persona (`LLM_ROLE`)**: operator-assignable free-form persona that shapes the assistant's tone, focus, and scope while remaining subordinate to safety, honesty, privacy, and hard-rule invariants.
+- **`AGENTS.md` / `CLAUDE.md` convention**: the assistant now looks for and reads project guidance files before working with code (applies to both the main agent and sub-agents).
+
+### Changed
+- **Sub-agent prompt**: filesystem & operations rules are now included only when filesystem access is enabled, reducing prompt size otherwise.
+
+### Fixed
+- **Command moderation**: added a plain-text JSON verdict fallback for models that don't honor forced tool calls (e.g. MiniMax M2.7/M3 on the Anthropic-compatible API), and fixed a crash when no tool call was returned.
+
 ## [1.9.0] - 2026-06-02
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Custom agent role/persona (`LLM_ROLE`)**: operator-assignable free-form persona that shapes the assistant's tone, focus, and scope while remaining subordinate to safety, honesty, privacy, and hard-rule invariants.
 - **`AGENTS.md` / `CLAUDE.md` convention**: the assistant now looks for and reads project guidance files before working with code (applies to both the main agent and sub-agents).
+- **Group chat shared context**: in group chats, the bot maintains a single shared conversation context common to all channel members, rather than per-user isolation.
 
 ### Changed
 - **Sub-agent prompt**: filesystem & operations rules are now included only when filesystem access is enabled, reducing prompt size otherwise.

--- a/chibi/config/gpt.py
+++ b/chibi/config/gpt.py
@@ -75,6 +75,7 @@ class GPTSettings(BaseSettings):
 
     filesystem_access: bool = Field(default=False)
     allow_delegation: bool = Field(default=True)
+    llm_role_raw: str | None = Field(alias="LLM_ROLE", default=None)
     delegate_task_timeout: int | None = Field(default=None)
     tools_whitelist_raw: str | None = Field(alias="TOOLS_WHITELIST", default=None)
 
@@ -86,8 +87,24 @@ class GPTSettings(BaseSettings):
         return bool(self.google_search_api_key) and bool(self.google_search_cx)
 
     @property
+    def llm_role(self) -> str | None:
+        """Return the free-form role/persona text configured via ``LLM_ROLE``.
+
+        The value is arbitrary operator-supplied prose; there is no fixed set of
+        roles. Returns the stripped text, or ``None`` when unset/blank so the
+        default agent behavior is preserved.
+        """
+        if not self.llm_role_raw or not self.llm_role_raw.strip():
+            return None
+        return self.llm_role_raw.strip()
+
+    @property
     def assistant_prompt(self) -> str:
-        return get_llm_prompt(filesystem_access=self.filesystem_access, allow_delegation=self.allow_delegation)
+        return get_llm_prompt(
+            filesystem_access=self.filesystem_access,
+            allow_delegation=self.allow_delegation,
+            role=self.llm_role,
+        )
 
     @property
     def models_whitelist(self) -> list[str]:

--- a/chibi/constants.py
+++ b/chibi/constants.py
@@ -161,36 +161,101 @@ to a particular file). This is to facilitate potential delegation of these atomi
 **Consider delegation**: For complex tasks, especially those involving large data or multiple independent subtasks,
 use the `delegate_task` tool to maintain clean context and optimize performance. You should actively look for delegation
 opportunities in your decomposition.
-2. **Start immediately and proceed autonomously once the task and its premises are valid or clarified**
+2. **When working with code (a codebase, project, repository, or any code task), ALWAYS look for an `AGENTS.md`
+file first. If `AGENTS.md` is absent, look for `CLAUDE.md`. Read and study it BEFORE starting the actual work — it
+contains project-specific conventions, constraints, and instructions you are expected to follow.**
+3. **Start immediately and proceed autonomously once the task and its premises are valid or clarified**
 Ask for input only if **genuinely impossible to proceed** due to critical ambiguity or missing information. The user
 assumes that you act independently, autonomously (see Guiding Principles). Do not wait for the user's confirmation
 for every step or action unless it is critically necessary.
-2.1 **If asked to "get acquainted" with a project or directory, autonomously determine which files and directories
+3.1 **If asked to "get acquainted" with a project or directory, autonomously determine which files and directories
 are most relevant (e.g., README, configuration files, dependency lists, main source files, test directories) and
 examine them without explicit instruction for each one.**
-3. However, if after receiving the task and initial analysis, you identify questions that are critical and
+4. However, if after receiving the task and initial analysis, you identify questions that are critical and
 blockingly essential for task completion, ask the user for clarification immediately. These must be genuinely vital
 questions, without answers to which the task cannot be solved, not for trivial choices or confirmations.
-4. Limit raw output to 30 lines unless the user asks for more.
-5. If several valid approaches exist, choose a sensible default (**without asking for confirmation unless the choice
+5. Limit raw output to 30 lines unless the user asks for more.
+6. If several valid approaches exist, choose a sensible default (**without asking for confirmation unless the choice
 has significant, irreversible consequences**).
-6. On problems, try alternatives before asking the user.
-7. If forced to pause (tool‑call limits, permissions, etc.), state clearly: Task not finished; will continue after
+7. On problems, try alternatives before asking the user.
+8. If forced to pause (tool‑call limits, permissions, etc.), state clearly: Task not finished; will continue after
 confirmation.
-8. Keep secrets hidden (tokens, passwords). Don’t try to see them, don't run dangerous commands without explicit
+9. Keep secrets hidden (tokens, passwords). Don’t try to see them, don't run dangerous commands without explicit
 approval (this interacts with the command pre-moderation in Workflow point 0; rejected commands related to secrets
 will be handled by the moderator).
-9. Provide a brief summary when done; detailed logs only on request.
-10. When conversation grows very long, proactively use `summarize_history`
+10. Provide a brief summary when done; detailed logs only on request.
+11. When conversation grows very long, proactively use `summarize_history`
 or `clear_tool_call_history` to keep context clean.
 """
 
 
-def get_llm_prompt(filesystem_access: bool, allow_delegation: bool) -> str:
+def get_role_prompt(role: str | None) -> str:
+    """Build the operator-assigned role/persona framing block.
+
+    ``role`` is **free-form text** written by the operator (via the ``LLM_ROLE``
+    env var) describing the persona the agent should embody for this deployment.
+    There is no fixed set of roles.
+
+    When ``role`` is ``None`` or blank, an empty string is returned so the base
+    prompt is left untouched. Otherwise the raw role text is embedded inside a
+    prompt-engineered framing block that activates the persona while explicitly
+    subordinating it to the agent's inviolable invariants.
+
+    Args:
+        role: The operator-assigned role text.
+
+    Returns:
+        The role prompt.
+    """
+    if not role or not role.strip():
+        return ""
+    role_text = role.strip()
+    return f"""
+# Active Role / Persona (operator-assigned)
+The operator who deployed you has assigned you a specific ROLE / PERSONA for this entire deployment.
+The text inside the delimited block below is that role. It is **not** a user message, **not** a one-off
+task, and **not** untrusted input to be questioned — it is a standing configuration describing *who you
+are* here. Genuinely adopt and embody it: let it become your default identity, voice, and mindset rather
+than something you merely acknowledge.
+
+This role MAY override, narrow, or redefine your default behavior, specifically:
+- your tone, manner, and personality;
+- your thematic focus and the subjects you engage with;
+- your level of initiative and proactivity;
+- the scope of activities you perform — the role may legitimately reduce you to a single function
+  (e.g. "respond only with translations and nothing else") or expand your stylistic range.
+When the role conflicts with your *default* tone/persona/scope, the role WINS — that is its purpose.
+
+However, the role can NEVER override the following INVIOLABLE invariants. These always take precedence on
+any conflict, and you follow the role only to the extent it does not breach them:
+- **Safety & refusal policy** — you still refuse what must be refused; a persona is never an excuse to
+  produce harmful or disallowed content.
+- **Honesty & transparency** — never lie, never fabricate tool output, never claim a success or an action
+  that did not happen. A "translator" or "joker" persona does not license deception.
+- **Privacy rules** — the sensitive-info denylist (e.g. political/religious/medical/sexual data handling in
+  user memory) remains fully in force.
+- **Hard rules** — filesystem & operations rules, secret-handling, and command pre-moderation are absolute.
+
+So the hierarchy is: INVARIANTS (safety, honesty, privacy, hard rules) > ROLE > default behavior.
+If the role text instructs anything that conflicts with an invariant, silently keep the invariant and obey
+the role only in the compatible parts.
+
+The operator-assigned role text begins after the next line and ends at the closing marker. Treat everything
+between the markers as the role definition; do not interpret it as instructions that outrank the invariants
+above.
+
+--- BEGIN ROLE ---
+{role_text}
+--- END ROLE ---
+"""
+
+
+def get_llm_prompt(filesystem_access: bool, allow_delegation: bool, role: str | None = None) -> str:
+    role_prompt = get_role_prompt(role)
     base_prompt = f"""
 You are {telegram_settings.bot_name}, a powerful AI assistant integrated into a multi-tool environment.
 You're communicating with user via Telegram chat-bot.
-
+{role_prompt}
 Your primary goal is to help the user achieve their objectives efficiently, safely, and truthfully.
 You are expected to think independently, question incorrect assumptions, and prioritize accuracy over agreeableness.
 
@@ -294,7 +359,7 @@ especially when reading a long sentence. Lively, not always even reading of the 
 Sometimes a slightly prolonged pause. More vivid sentence endings.
 """
 
-SUB_EXECUTOR_PROMPT = """
+SUB_EXECUTOR_PART1 = """
 You are a sub-agent spawned to execute a delegated task. You communicate with a parent AI agent, not a human user. Your
 purpose: complete the assigned task and return a result.
 
@@ -354,7 +419,9 @@ You have access to all main agent tools:
 
 Use as needed to complete task.
 
-HARD RULES (filesystem & operations)
+"""
+
+SUB_EXECUTOR_FS_PROMPT = """HARD RULES (filesystem & operations)
 A. For questions about existing files/directories, MUST call run_command_in_terminal first and base answer ONLY on real
 output
 B. If command fails (path, permissions, etc), retry or report in failure description. Do NOT invent or assume data
@@ -362,12 +429,17 @@ C. Never fabricate tool output
 D. Violating A-C means task not completed; redo step correctly immediately
 E. Assume exclusive access to files/directories you work on unless specified otherwise. Files won't change during your
 work, avoid redundant checks
+F. When working with code, ALWAYS look for an `AGENTS.md` file first. If absent, look for `CLAUDE.md`. Read it before
+starting the actual work — it contains project-specific conventions and instructions you must follow.
+G. Keep secrets hidden (tokens, passwords, keys). Do not attempt to read or expose them, do not run dangerous commands.
 
 COMMAND MODERATION
 All terminal commands are pre-moderated. If rejected, you receive reason. Do not retry rejected commands within
 10 minutes. If critical command blocked, report in failure description.
 
-COMMUNICATION STYLE
+"""
+
+SUB_EXECUTOR_PART2 = """COMMUNICATION STYLE
 - Machine-to-machine: communicating with AI agent, not human. Optimize for clarity and information density
 - Concise and direct: no fluff, emojis, pleasantries, conversational padding
 - Structured: use clear formatting when appropriate (lists, code blocks, sections)
@@ -397,3 +469,9 @@ There are 247 lines with ERROR in them. That's interesting! Here are the first 1
 You are a focused task executor, not conversational agent. Complete task, return result, done.
 
 """
+
+
+def get_sub_executor_prompt(filesystem_access: bool) -> str:
+    if filesystem_access:
+        return SUB_EXECUTOR_PART1 + SUB_EXECUTOR_FS_PROMPT + SUB_EXECUTOR_PART2
+    return SUB_EXECUTOR_PART1 + SUB_EXECUTOR_PART2

--- a/chibi/runners/telegram.py
+++ b/chibi/runners/telegram.py
@@ -139,7 +139,7 @@ class ChibiBot:
         interface = TelegramInterface(update=update, context=context)
         task_manager.run_task(
             coro=handle_drop_thread(interface=interface, args=args),
-            user_id=interface.user_id,
+            user_id=interface.storage_id,
         )
         return None
 
@@ -156,7 +156,7 @@ class ChibiBot:
         interface = TelegramInterface(update=update, context=context)
         task_manager.run_task(
             coro=handle_new_thread(interface=interface, args=args),
-            user_id=interface.user_id,
+            user_id=interface.storage_id,
         )
         return None
 
@@ -173,7 +173,7 @@ class ChibiBot:
         interface = TelegramInterface(update=update, context=context)
         task_manager.run_task(
             coro=handle_clone_thread(interface=interface, args=args),
-            user_id=interface.user_id,
+            user_id=interface.storage_id,
         )
         return None
 
@@ -198,7 +198,7 @@ class ChibiBot:
             interface = TelegramInterface(update=update, context=context)
             task_manager.run_task(
                 coro=handle_image_generation(prompt=prompt, interface=interface),
-                user_id=interface.user_id,
+                user_id=interface.user_id,  # Keep user_id: image quotas are per-user, not per-chat
             )
             return None
 
@@ -256,7 +256,7 @@ class ChibiBot:
         if await interface.get_caption():
             task_manager.run_task(
                 coro=handle_user_prompt(interface=interface),
-                user_id=interface.user_id,
+                user_id=interface.storage_id,
             )
         return None
 
@@ -272,7 +272,7 @@ class ChibiBot:
         if telegram_message.voice:
             task_manager.run_task(
                 coro=handle_user_prompt(interface=interface),
-                user_id=interface.user_id,
+                user_id=interface.storage_id,
             )
             return None
 
@@ -289,7 +289,7 @@ class ChibiBot:
             set_user_action(context=context, action=UserAction.NONE)
             task_manager.run_task(
                 coro=handle_image_generation(prompt=prompt, interface=interface),
-                user_id=interface.user_id,
+                user_id=interface.user_id,  # Keep user_id: image quotas are per-user, not per-chat
             )
             return None
 
@@ -303,7 +303,7 @@ class ChibiBot:
 
         task_manager.run_task(
             coro=handle_user_prompt(interface=interface),
-            user_id=interface.user_id,
+            user_id=interface.storage_id,
         )
         return None
 
@@ -312,7 +312,7 @@ class ChibiBot:
         interface = TelegramInterface(update=update, context=context)
         task_manager.run_task(
             coro=handle_user_prompt(interface=interface),
-            user_id=interface.user_id,
+            user_id=interface.storage_id,
         )
         return None
 
@@ -667,8 +667,9 @@ class ChibiBot:
         if not message:
             return None
 
-        telegram_user = get_telegram_user(update=update)
+        # telegram_user = get_telegram_user(update=update)
         thread_id = message.message_thread_id or 0
+        interface = TelegramInterface(update=update, context=context)
 
         from chibi.storage.database import inject_database
 
@@ -678,7 +679,7 @@ class ChibiBot:
 
             Args:
                 db: The database instance injected by the decorator.
-                user_id: The Telegram user ID.
+                user_id: The storage ID for the chat (user_id for private, chat_id for groups).
                 thread_id: The thread ID to sync.
             """
             from chibi.models import User
@@ -698,7 +699,7 @@ class ChibiBot:
             if updated:
                 await db.save_user(user)
 
-        await do_sync(user_id=telegram_user.id, thread_id=thread_id)
+        await do_sync(user_id=interface.storage_id, thread_id=thread_id)
         return None
 
     async def error_handler(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/chibi/runners/terminal.py
+++ b/chibi/runners/terminal.py
@@ -99,7 +99,7 @@ class TerminalRunner:
     async def _handle_reset(self) -> None:
         """Reset chat history."""
         console.print("[yellow]Resetting chat history...[/yellow]")
-        await reset_chat_history(user_id=self.user_id, thread_id=0)
+        await reset_chat_history(storage_id=self.user_id, thread_id=0)
         console.print("[green]Chat history has been reset.[/green]")
 
     async def _handle_model_selection(self) -> None:

--- a/chibi/services/bot.py
+++ b/chibi/services/bot.py
@@ -43,7 +43,7 @@ async def handle_model_selection(
 
 async def handle_tool_response(tool_response: ToolResponseSchema, interface: UserInterface) -> None:
     chat_response: ChatResponseSchema = await get_llm_chat_completion_answer(
-        user_id=interface.user_id, tool_message=tool_response, interface=interface
+        storage_id=interface.storage_id, tool_message=tool_response, interface=interface
     )
     usage_message = get_usage_msg(chat_response.usage)
 
@@ -121,7 +121,7 @@ async def handle_user_prompt(interface: UserInterface) -> None:
 
     async with indicator(coro_func=interface.send_action_typing):
         chat_response: ChatResponseSchema = await get_llm_chat_completion_answer(
-            user_id=interface.user_id,
+            storage_id=interface.storage_id,
             user_text_message=text_prompt,
             user_voice_message=voice_prompt,
             user_caption=caption_prompt,
@@ -153,7 +153,9 @@ async def handle_user_prompt(interface: UserInterface) -> None:
         f"the {interface.chat_data}. {logged_answer} {usage_message}"
     )
     await interface.send_message(message=chat_response.answer)
-    history_is_summarized = await check_history_and_summarize(user_id=interface.user_id, thread_id=interface.thread_id)
+    history_is_summarized = await check_history_and_summarize(
+        storage_id=interface.storage_id, thread_id=interface.thread_id
+    )
     if history_is_summarized:
         logger.info(f"{interface.user_data}: history successfully summarized.")
     return None
@@ -162,7 +164,7 @@ async def handle_user_prompt(interface: UserInterface) -> None:
 async def handle_reset(interface: UserInterface) -> None:
     logger.info(f"{interface.user_data}: conversation history reset.")
 
-    await reset_chat_history(user_id=interface.user_id, thread_id=interface.thread_id)
+    await reset_chat_history(storage_id=interface.storage_id, thread_id=interface.thread_id)
     task_manager.kill_all_user_tasks(user_id=interface.user_id)
     await interface.send_message(message="Done!", reply=False)
 
@@ -272,7 +274,7 @@ async def handle_new_thread(interface: UserInterface, args: list[str] | None = N
             )
             return None
 
-        await save_thread_name(user_id=interface.user_id, thread_id=new_thread_id, name=name)
+        await save_thread_name(storage_id=interface.storage_id, thread_id=new_thread_id, name=name)
         await interface.send_message(message=f"✅ Thread created: {name} (ID: {new_thread_id})")
     except Exception as e:
         logger.error(f"{interface.user_data}: Error in /new_thread: {e}")
@@ -286,7 +288,7 @@ async def handle_clone_thread(interface: UserInterface, args: list[str] | None =
         interface: The user interface instance.
         args: Optional list of arguments for the cloned thread name.
     """
-    user = await get_chibi_user(user_id=interface.user_id)
+    user = await get_chibi_user(user_id=interface.storage_id)
     name = " ".join(args).strip() if args else None
 
     if not name:
@@ -301,7 +303,7 @@ async def handle_clone_thread(interface: UserInterface, args: list[str] | None =
         return None
 
     cloned_messages = await clone_thread_messages(
-        user_id=interface.user_id, old_thread_id=interface.thread_id, new_thread_id=new_thread_id
+        storage_id=interface.storage_id, old_thread_id=interface.thread_id, new_thread_id=new_thread_id
     )
     message = f"✅ Thread cloned: {name} (ID: {new_thread_id}). {cloned_messages} messages copied."
 
@@ -336,6 +338,6 @@ async def handle_drop_thread(interface: UserInterface, args: list[str] | None = 
         )
         return None
 
-    await reset_chat_history(user_id=interface.user_id, thread_id=interface.thread_id)
-    await delete_thread_from_map(user_id=interface.user_id, thread_id=interface.thread_id)
+    await reset_chat_history(storage_id=interface.storage_id, thread_id=interface.thread_id)
+    await delete_thread_from_map(storage_id=interface.storage_id, thread_id=interface.thread_id)
     return None

--- a/chibi/services/interface.py
+++ b/chibi/services/interface.py
@@ -8,7 +8,7 @@ from telegram import File, Update
 from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
-from chibi.constants import AUDIO_UPLOAD_TIMEOUT, FILE_UPLOAD_TIMEOUT
+from chibi.constants import AUDIO_UPLOAD_TIMEOUT, FILE_UPLOAD_TIMEOUT, GROUP_CHAT_TYPES
 from chibi.utils.telegram import send_answer_message, send_images
 
 
@@ -28,6 +28,17 @@ class UserInterface(ABC):
 
         Returns:
             The user identifier.
+        """
+        raise NotImplementedError
+
+    @property
+    def storage_id(self) -> int:
+        """Returns the storage key for persisting conversation/context.
+
+        Private chats -> user_id (== chat_id). Group chats -> chat_id (shared).
+
+        Returns:
+            The storage identifier.
         """
         raise NotImplementedError
 
@@ -281,6 +292,19 @@ class TelegramInterface(UserInterface):
         if user := self.update.effective_user:
             return user.id
         raise ValueError("Telegram incoming update does not contain valid user data.")
+
+    @property
+    def storage_id(self) -> int:
+        """Returns the storage key for persisting conversation/context.
+
+        Private chats -> user_id (== chat_id). Group chats -> chat_id (shared among all participants).
+
+        Returns:
+            The storage identifier.
+        """
+        if self._chat.type in GROUP_CHAT_TYPES:
+            return int(self._chat.id)
+        return self.user_id
 
     @property
     def user_data(self) -> str:

--- a/chibi/services/providers/minimax.py
+++ b/chibi/services/providers/minimax.py
@@ -16,7 +16,7 @@ class Minimax(AnthropicFriendlyProvider):
     name = "Minimax"
     base_url = "https://api.minimax.io/anthropic"
     default_model = "MiniMax-M2.7"
-    default_moderation_model = "MiniMax-M2.7-lighting"
+    default_moderation_model = "MiniMax-M2.5-lighting"
     model_name_keywords = ["MiniMax"]
 
     base_tts_url = "https://api.minimax.io/v1/"
@@ -59,7 +59,11 @@ class Minimax(AnthropicFriendlyProvider):
         if not models:
             # Get models endpoint sometimes returns empty list, so we need a hacky fallback here
             supported_models = [
-                "MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"
+                "MiniMax-M3",
+                "MiniMax-M2.7",
+                "MiniMax-M2.7-highspeed",
+                "MiniMax-M2.5",
+                "MiniMax-M2.5-highspeed",
             ]
             models = [
                 ModelChangeSchema(

--- a/chibi/services/providers/provider.py
+++ b/chibi/services/providers/provider.py
@@ -3,6 +3,7 @@ import base64
 import inspect
 import json
 import random
+import re
 from abc import ABC
 from asyncio import sleep
 from functools import wraps
@@ -960,6 +961,10 @@ class AnthropicFriendlyProvider(RestApiFriendlyProvider):
     async def moderate_command(self, cmd: str, model: str | None = None) -> ModeratorsAnswer:
         moderator_model = model or self.default_moderation_model or self.default_model
         messages = [Message(role="user", content=cmd).to_anthropic()]
+        moderator_prompt = (
+            MODERATOR_PROMPT + "\n**HARD RULE:** call the print_moderator_verdict tool to provide your verdict"
+        )
+
         response_message: AnthropicMessage = await self.client.messages.create(
             model=moderator_model,
             max_tokens=1024,
@@ -967,14 +972,14 @@ class AnthropicFriendlyProvider(RestApiFriendlyProvider):
             timeout=self.timeout,
             system=[
                 TextBlockParam(
-                    text=MODERATOR_PROMPT,
+                    text=moderator_prompt,
                     type="text",
                 )
             ],
             tools=[
                 ToolParam(
                     name="print_moderator_verdict",
-                    description="Provide moderator's verdict",
+                    description="Provide moderator's verdict via calling this tool.",
                     input_schema=InputSchemaTyped(
                         type="object",
                         properties={
@@ -996,16 +1001,39 @@ class AnthropicFriendlyProvider(RestApiFriendlyProvider):
         if application_settings.is_influx_configured:
             MetricsService.send_usage_metrics(metric=usage, model=moderator_model, provider=self.name)
         tool_call: ToolUseBlock | None = next(
-            part for part in response_message.content if isinstance(part, ToolUseBlock)
+            (part for part in response_message.content if isinstance(part, ToolUseBlock)), None
         )
-        if not tool_call:
+
+        if tool_call is not None:
+            answer = tool_call.input
+            try:
+                return ModeratorsAnswer.model_validate(answer, extra="ignore")
+            except Exception as e:
+                msg = f"Error parsing moderator's response: {answer}. Error: {e}"
+                logger.error(msg)
+                return ModeratorsAnswer(verdict="declined", reason=msg, status="error")
+
+        # Fallback: some models (e.g. MiniMax M2.7/M3 on the Anthropic-compatible API) ignore the
+        # forced tool_choice and reply with plain text instead of a tool_use block. The moderator
+        # prompt already instructs the model to emit a JSON verdict as plain text, so we parse it.
+        text_part: TextBlock | None = next(
+            (part for part in response_message.content if isinstance(part, TextBlock)), None
+        )
+        if text_part is None or not text_part.text.strip():
             return ModeratorsAnswer(status="error", verdict="declined", reason="no response from moderator received")
-        answer = tool_call.input
+
+        raw_text = text_part.text.strip()
+        match = re.search(r"\{.*\}", raw_text, re.DOTALL)
+        if match is None:
+            msg = f"Moderator returned no tool call and no JSON verdict. Raw: {raw_text[:200]}"
+            logger.error(msg)
+            return ModeratorsAnswer(verdict="declined", reason=msg, status="error")
 
         try:
-            return ModeratorsAnswer.model_validate(answer, extra="ignore")
+            parsed = json.loads(match.group(0))
+            return ModeratorsAnswer.model_validate(parsed, extra="ignore")
         except Exception as e:
-            msg = f"Error parsing moderator's response: {answer}. Error: {e}"
+            msg = f"Error parsing moderator's text verdict: {raw_text[:200]}. Error: {e}"
             logger.error(msg)
             return ModeratorsAnswer(verdict="declined", reason=msg, status="error")
 

--- a/chibi/services/providers/tools/memory.py
+++ b/chibi/services/providers/tools/memory.py
@@ -148,7 +148,7 @@ class ClearToolCallHistoryTool(ChibiTool):
         interface = cls.get_interface(kwargs=kwargs)
 
         logger.log("TOOL", f"[{kwargs.get('caller_model', 'unknown model')}] Clearing tool call history")
-        await drop_tool_call_history(user_id=user_id, thread_id=interface.thread_id)
+        await drop_tool_call_history(storage_id=user_id, thread_id=interface.thread_id)
         return {"status": "ok"}
 
 
@@ -184,7 +184,7 @@ class SummarizeHistoryTool(ChibiTool):
         interface = cls.get_interface(kwargs=kwargs)
 
         logger.log("TOOL", f"[{kwargs.get('caller_model', 'unknown model')}] Summarizing chat...")
-        await summarize_history(user_id=user_id, thread_id=interface.thread_id)
+        await summarize_history(storage_id=user_id, thread_id=interface.thread_id)
         if application_settings.log_prompt_data:
             logger.log("TOOL", f"[{kwargs.get('caller_model', 'unknown model')}] Summary: {summary}")
         return {"status": "ok"}

--- a/chibi/services/providers/tools/topic.py
+++ b/chibi/services/providers/tools/topic.py
@@ -80,6 +80,6 @@ class RenameThreadTool(ChibiTool):
                 "Failed to rename the topic. Make sure the bot has the required permissions (can manage topics)."
             )
 
-        await save_thread_name(user_id=user_id, thread_id=interface.thread_id, name=name)
+        await save_thread_name(storage_id=user_id, thread_id=interface.thread_id, name=name)
 
         return {"status": "ok", "message": f"Thread successfully renamed to '{name}'."}

--- a/chibi/services/providers/tools/utils.py
+++ b/chibi/services/providers/tools/utils.py
@@ -11,7 +11,7 @@ from httpx import Response
 from loguru import logger
 
 from chibi.config import gpt_settings
-from chibi.constants import SUB_EXECUTOR_PROMPT
+from chibi.constants import get_sub_executor_prompt
 from chibi.models import Message
 from chibi.schemas.app import ChatResponseSchema, ModelChangeSchema
 from chibi.services.interface import UserInterface
@@ -124,7 +124,10 @@ async def get_sub_agent_response(
     ]
 
     chat_response, _ = await provider.get_chat_response(
-        messages=conversation_messages, user=user, model=model_name, system_prompt=SUB_EXECUTOR_PROMPT
+        messages=conversation_messages,
+        user=user,
+        model=model_name,
+        system_prompt=get_sub_executor_prompt(gpt_settings.filesystem_access),
     )
     return chat_response
 

--- a/chibi/services/user.py
+++ b/chibi/services/user.py
@@ -31,7 +31,7 @@ async def get_chibi_user(db: Database, user_id: int) -> User:
 
 @inject_database
 async def set_active_model(db: Database, interface: UserInterface, model: ModelChangeSchema) -> None:
-    user = await db.get_or_create_user(user_id=interface.user_id)
+    user = await db.get_or_create_user(user_id=interface.storage_id)
     if model.image_generation:
         user.thread_selected_image_model[interface.thread_id] = SelectedModel(
             name=model.name, provider_name=model.provider
@@ -42,14 +42,14 @@ async def set_active_model(db: Database, interface: UserInterface, model: ModelC
 
 
 @inject_database
-async def reset_chat_history(db: Database, user_id: int, thread_id: int) -> None:
-    user = await db.get_or_create_user(user_id=user_id)
+async def reset_chat_history(db: Database, storage_id: int, thread_id: int) -> None:
+    user = await db.get_or_create_user(user_id=storage_id)
     await db.drop_messages(user=user, thread_id=thread_id)
 
 
 @inject_database
-async def emergency_summarization(db: Database, user_id: int, thread_id: int) -> None:
-    user = await db.get_or_create_user(user_id=user_id)
+async def emergency_summarization(db: Database, storage_id: int, thread_id: int) -> None:
+    user = await db.get_or_create_user(user_id=storage_id)
 
     chat_history = await db.get_messages(user=user, thread_id=thread_id)
     chat_history_string = str(msg for msg in chat_history if not any((msg.get("tool_calls"), msg.get("tool_call_id"))))
@@ -62,7 +62,7 @@ async def emergency_summarization(db: Database, user_id: int, thread_id: int) ->
     )
     initial_message = Message(role="user", content="What we were talking about?")
     answer_message = Message(role="assistant", content=response.answer)
-    await reset_chat_history(user_id=user_id, thread_id=thread_id)
+    await reset_chat_history(storage_id=storage_id, thread_id=thread_id)
     await db.add_message(user=user, message=initial_message, ttl=gpt_settings.messages_ttl, thread_id=thread_id)
     await db.add_message(user=user, message=answer_message, ttl=gpt_settings.messages_ttl, thread_id=thread_id)
 
@@ -70,14 +70,14 @@ async def emergency_summarization(db: Database, user_id: int, thread_id: int) ->
 @inject_database
 async def send_scheduled_message_to_llm(
     db: Database,
-    user_id: int,
+    storage_id: int,
     interface: UserInterface,
     message: str,
     event_id: UUID,
     thread_id: int = 0,
 ) -> ChatResponseSchema:
-    user = await db.get_or_create_user(user_id=user_id)
-    lock = await LockManager().get_lock(key=f"{user_id}_{thread_id}")
+    user = await db.get_or_create_user(user_id=storage_id)
+    lock = await LockManager().get_lock(key=f"{storage_id}_{thread_id}")
 
     prompt = {
         "type": "scheduled message",
@@ -104,8 +104,8 @@ async def send_scheduled_message_to_llm(
 
 
 @inject_database
-async def save_telegram_document_metadata(db: Database, user_id: int, file_metadata: dict[str, Any]) -> str:
-    user = await db.get_or_create_user(user_id=user_id)
+async def save_telegram_document_metadata(db: Database, storage_id: int, file_metadata: dict[str, Any]) -> str:
+    user = await db.get_or_create_user(user_id=storage_id)
     file_meta = TelegramFileMeta(**file_metadata)
     files_update = {
         file_meta.file_unique_id: file_meta,
@@ -120,8 +120,8 @@ async def save_telegram_document_metadata(db: Database, user_id: int, file_metad
 
 
 @inject_database
-async def get_telegram_documents(db: Database, user_id: int, limit: int = 0) -> dict[str, TelegramFileMeta]:
-    user = await db.get_or_create_user(user_id=user_id)
+async def get_telegram_documents(db: Database, storage_id: int, limit: int = 0) -> dict[str, TelegramFileMeta]:
+    user = await db.get_or_create_user(user_id=storage_id)
     files = user.telegram_files
     if limit == 0:
         return files
@@ -131,24 +131,24 @@ async def get_telegram_documents(db: Database, user_id: int, limit: int = 0) -> 
 
 
 @inject_database
-async def get_telegram_document(db: Database, user_id: int, file_unique_id: str) -> TelegramFileMeta | None:
-    user = await db.get_or_create_user(user_id=user_id)
+async def get_telegram_document(db: Database, storage_id: int, file_unique_id: str) -> TelegramFileMeta | None:
+    user = await db.get_or_create_user(user_id=storage_id)
     return user.telegram_files.get(file_unique_id)
 
 
 @inject_database
 async def get_llm_chat_completion_answer(
     db: Database,
-    user_id: int,
+    storage_id: int,
     interface: UserInterface,
     user_text_message: str | None = None,
     user_voice_message: BytesIO | None = None,
     user_caption: str | None = None,
     tool_message: Optional["ToolResponseSchema"] = None,
 ) -> ChatResponseSchema:
-    user = await db.get_or_create_user(user_id=user_id)
+    user = await db.get_or_create_user(user_id=storage_id)
     thread_id = interface.thread_id
-    lock = await LockManager().get_lock(key=f"{user_id}_{thread_id}")
+    lock = await LockManager().get_lock(key=f"{storage_id}_{thread_id}")
 
     if not user_text_message and not user_voice_message and not tool_message and not user_caption:
         raise ValueError("No prompt data provided")
@@ -179,6 +179,7 @@ async def get_llm_chat_completion_answer(
         )
         assert user_message
         prompt = {
+            "user": interface.user_data,
             "prompt": user_message,
             "datetime_now": datetime.datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z%z"),
             "type": "user message",
@@ -205,15 +206,15 @@ async def get_llm_chat_completion_answer(
 
 
 @inject_database
-async def check_history_and_summarize(db: Database, user_id: int, thread_id: int) -> bool:
-    user = await db.get_or_create_user(user_id=user_id)
+async def check_history_and_summarize(db: Database, storage_id: int, thread_id: int) -> bool:
+    user = await db.get_or_create_user(user_id=storage_id)
     messages: list[Message] = await db.get_conversation_messages(user=user, thread_id=thread_id)
     # Roughly estimating how many tokens the current conversation history will comprise. It is possible to calculate
     # this accurately, but the modules that can be used for this need to be separately built for armv7, which is
     # difficult to do right now (but will be done further, I hope).
     tokens = sum(msg.estimate_tokens for msg in messages)
     if tokens >= gpt_settings.max_history_tokens:
-        await emergency_summarization(user_id=user_id, thread_id=thread_id)
+        await emergency_summarization(storage_id=storage_id, thread_id=thread_id)
         return True
     return False
 
@@ -388,10 +389,10 @@ async def get_moderation_provider(db: Database, user_id: int) -> "Provider":
 
 
 @inject_database
-async def drop_tool_call_history(db: Database, user_id: int, thread_id: int) -> None:
-    user = await db.get_or_create_user(user_id=user_id)
+async def drop_tool_call_history(db: Database, storage_id: int, thread_id: int) -> None:
+    user = await db.get_or_create_user(user_id=storage_id)
     chat_history: list[Message] = await db.get_conversation_messages(user=user, thread_id=thread_id)
-    await reset_chat_history(user_id=user_id, thread_id=thread_id)
+    await reset_chat_history(storage_id=storage_id, thread_id=thread_id)
     for message in chat_history:
         if message.role == "tool":
             continue
@@ -401,38 +402,38 @@ async def drop_tool_call_history(db: Database, user_id: int, thread_id: int) -> 
 
 
 @inject_database
-async def summarize_history(db: Database, user_id: int, thread_id: int) -> None:
-    user = await db.get_or_create_user(user_id=user_id)
+async def summarize_history(db: Database, storage_id: int, thread_id: int) -> None:
+    user = await db.get_or_create_user(user_id=storage_id)
     chat_history: list[Message] = await db.get_conversation_messages(user=user, thread_id=thread_id)
-    await reset_chat_history(user_id=user_id, thread_id=thread_id)
+    await reset_chat_history(storage_id=storage_id, thread_id=thread_id)
     await db.add_message(user=user, message=chat_history[0], ttl=gpt_settings.messages_ttl, thread_id=thread_id)
 
 
 @inject_database
-async def save_thread_name(db: Database, user_id: int, thread_id: int, name: str) -> None:
+async def save_thread_name(db: Database, storage_id: int, thread_id: int, name: str) -> None:
     """Save the name of a specific thread for the user.
 
     Args:
         db: The database instance.
-        user_id: The ID of the user.
+        storage_id: The storage ID (user_id for private, chat_id for groups).
         thread_id: The ID of the thread.
         name: The name to save for the thread.
     """
-    user = await db.get_or_create_user(user_id=user_id)
+    user = await db.get_or_create_user(user_id=storage_id)
     user.thread_names[thread_id] = name
     await db.save_user(user)
 
 
 @inject_database
-async def delete_thread_from_map(db: Database, user_id: int, thread_id: int) -> None:
+async def delete_thread_from_map(db: Database, storage_id: int, thread_id: int) -> None:
     """Delete a thread mapping from the user's saved thread names.
 
     Args:
         db: The database instance.
-        user_id: The ID of the user.
+        storage_id: The storage ID (user_id for private, chat_id for groups).
         thread_id: The ID of the thread to delete.
     """
-    user = await db.get_or_create_user(user_id=user_id)
+    user = await db.get_or_create_user(user_id=storage_id)
     user.thread_names.pop(thread_id)
     await db.save_user(user)
 
@@ -440,7 +441,7 @@ async def delete_thread_from_map(db: Database, user_id: int, thread_id: int) -> 
 @inject_database
 async def clone_thread_messages(
     db: Database,
-    user_id: int,
+    storage_id: int,
     old_thread_id: int,
     new_thread_id: int,
     name: str | None = None,
@@ -449,7 +450,7 @@ async def clone_thread_messages(
 
     Args:
         db: The database instance.
-        user_id: The ID of the user.
+        storage_id: The storage ID (user_id for private, chat_id for groups).
         old_thread_id: The ID of the thread to clone from.
         new_thread_id: The ID of the thread to clone to.
         name: The name of the new thread. Defaults to None.
@@ -457,7 +458,7 @@ async def clone_thread_messages(
     Returns:
         The number of messages that were cloned.
     """
-    user = await db.get_or_create_user(user_id=user_id)
+    user = await db.get_or_create_user(user_id=storage_id)
     existing_messages = await db.get_conversation_messages(user=user, thread_id=old_thread_id)
 
     for i, message in enumerate(existing_messages):

--- a/chibi/storage/files/telegram_storage.py
+++ b/chibi/storage/files/telegram_storage.py
@@ -15,12 +15,12 @@ class TelegramFileStorage(FileStorage):
 
     async def save(self, file_metadata: dict[str, Any]) -> str:
         return await save_telegram_document_metadata(
-            user_id=self.interface.user_id,
+            storage_id=self.interface.user_id,
             file_metadata=file_metadata,
         )
 
     async def get_bytes(self, file_id: str) -> bytes:
-        file_meta = await get_telegram_document(user_id=self.interface.user_id, file_unique_id=file_id)
+        file_meta = await get_telegram_document(storage_id=self.interface.user_id, file_unique_id=file_id)
         if not file_meta:
             raise FileNotFoundError(f"No file with ID '{file_id}' found")
 
@@ -37,7 +37,7 @@ class TelegramFileStorage(FileStorage):
         return base64.b64encode(file_bytes).decode("ascii")
 
     async def get_available_files(self, limit: int = 0) -> dict[str, str | int]:
-        files = await get_telegram_documents(user_id=self.interface.user_id, limit=limit)
+        files = await get_telegram_documents(storage_id=self.interface.user_id, limit=limit)
         return {
             file.file_unique_id: f"{file.file_name} ({file.short_description or 'description n/a'})"
             for file in files.values()
@@ -50,7 +50,7 @@ class TelegramFileStorage(FileStorage):
         raise NotImplementedError
 
     async def get_file_info(self, file_id: str) -> dict[str, Any]:
-        file_meta = await get_telegram_document(user_id=self.interface.user_id, file_unique_id=file_id)
+        file_meta = await get_telegram_document(storage_id=self.interface.user_id, file_unique_id=file_id)
         if not file_meta:
             raise FileNotFoundError(f"No file with ID '{file_id}' found")
         return file_meta.model_dump()

--- a/chibi/utils/telegram.py
+++ b/chibi/utils/telegram.py
@@ -527,11 +527,15 @@ def user_interacts_with_bot(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         True if the user is interacting with the bot, False otherwise.
     """
     telegram_message = get_telegram_message(update=update)
-    prompt = telegram_message.text
+    print(telegram_message.text)
+    # Check entities for mentions (e.g. @botname in Telegram UI)
+    if telegram_message.entities:
+        for entity in telegram_message.entities:
+            if entity.type == "mention" and entity.user:
+                if entity.user.id == context.bot.id:
+                    return True
 
-    if not prompt:
-        return False
-
+    prompt = telegram_message.text or ""
     if context.bot.first_name in prompt or context.bot.username in prompt:
         return True
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -62,8 +62,9 @@ Chibi admite múltiples proveedores detrás de una sola conversación. Añade un
 - **Mistral AI**
 - **Moonshot AI**
 - **MiniMax**
-- **Cloudflare Workers AI** (muchos modelos open-source)
 - **ZhipuAI** (modelos GLM)
+- **OpenRouter** (acceso unificado a muchos modelos)
+- **Cloudflare Workers AI** (muchos modelos open-source)
 
 ### Endpoints compatibles con OpenAI (autoalojado / local)
 
@@ -150,8 +151,9 @@ Cada proveedor requiere su propia clave API. Aquí están los enlaces directos:
 - **Mistral AI**: [console.mistral.ai](https://console.mistral.ai/)
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
-- **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (acceso unificado a muchos modelos): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
+- **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **Herramientas creativas:**
 - **ElevenLabs** (Voice): [elevenlabs.io](https://elevenlabs.io/)

--- a/docs/README.id.md
+++ b/docs/README.id.md
@@ -63,6 +63,7 @@ Chibi mendukung banyak penyedia dalam satu percakapan. Tambahkan satu API key at
 - **Moonshot AI**
 - **MiniMax**
 - **Cloudflare Workers AI** (banyak model open-source)
+- **OpenRouter** (akses terpadu ke banyak model)
 - **ZhipuAI** (model GLM)
 
 ### Endpoint kompatibel OpenAI (self-host / lokal)
@@ -151,6 +152,7 @@ Setiap penyedia memerlukan kunci API sendiri. Berikut adalah tautan langsung:
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
+- **OpenRouter** (akses terpadu ke banyak model): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
 
 **Alat Kreatif:**

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -63,6 +63,7 @@ Chibi は、単一の会話の中で複数プロバイダーを扱えます。�
 - **Moonshot AI**
 - **MiniMax**
 - **ZhipuAI**（GLMモデル）
+- **OpenRouter**（多数のモデルへの統合アクセス）
 - **Cloudflare Workers AI**（多数のオープンソースモデル）
 
 ### OpenAI互換エンドポイント（セルフホスト / ローカル）
@@ -164,6 +165,7 @@ docker-compose up -d
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (多数のモデルへの統合アクセス): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **クリエイティブツール：**

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -62,8 +62,9 @@ O Chibi suporta múltiplos provedores por trás de uma única conversa. Adicione
 - **Mistral AI**
 - **Moonshot AI**
 - **MiniMax**
-- **Cloudflare Workers AI** (muitos modelos open-source)
 - **ZhipuAI** (modelos GLM)
+- **OpenRouter** (acesso unificado a muitos modelos)
+- **Cloudflare Workers AI** (muitos modelos open-source)
 
 ### Endpoints compatíveis com OpenAI (auto-hospedado / local)
 
@@ -150,8 +151,9 @@ Cada provedor requer sua própria chave de API. Aqui estão os links diretos:
 - **Mistral AI**: [console.mistral.ai](https://console.mistral.ai/)
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
-- **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (acesso unificado a muitos modelos): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
+- **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **Ferramentas criativas:**
 - **ElevenLabs** (Voice): [elevenlabs.io](https://elevenlabs.io/)

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -63,6 +63,7 @@ Chibi поддерживает множество провайдеров в ра
 - **Moonshot AI**
 - **MiniMax**
 - **ZhipuAI** (модели GLM)
+- **OpenRouter** (унифицированный доступ ко многим моделям)
 - **Cloudflare Workers AI** (множество open‑source моделей)
 
 ### OpenAI‑совместимые endpoints (self‑host / local)
@@ -164,6 +165,7 @@ docker-compose up -d
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (унифицированный доступ ко многим моделям): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **Креативные инструменты:**

--- a/docs/README.tr.md
+++ b/docs/README.tr.md
@@ -63,6 +63,7 @@ Chibi, tek bir sohbetin arkasında birden fazla sağlayıcıyı destekler. Bir a
 - **Moonshot AI**
 - **MiniMax**
 - **Cloudflare Workers AI** (birçok açık kaynak model)
+- **OpenRouter** (birçok modele birleşik erişim)
 - **ZhipuAI** (GLM modelleri)
 
 ### OpenAI uyumlu endpoint’ler (self-host / local)
@@ -151,6 +152,7 @@ Her sağlayıcı kendi API anahtarını gerektirir. İşte doğrudan bağlantıl
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
+- **OpenRouter** (birçok modele birleşik erişim): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
 
 **Yaratıcı Araçlar:**

--- a/docs/README.uk.md
+++ b/docs/README.uk.md
@@ -46,6 +46,7 @@ Chibi підтримує кількох провайдерів у межах о�
 - **Moonshot AI**
 - **MiniMax**
 - **ZhipuAI** (моделі GLM)
+- **OpenRouter** (уніфікований доступ до багатьох моделей)
 - **Cloudflare Workers AI** (багато open-source моделей)
 
 ### OpenAI-сумісні ендпоінти (self-host / локально)
@@ -147,6 +148,7 @@ docker-compose up -d
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **ZhipuAI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (уніфікований доступ до багатьох моделей): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **Креативні інструменти:**

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -63,6 +63,7 @@ Chibi 在单一对话中支持多个提供商。添加一个或多个密钥—�
 - **月之暗面**（Moonshot AI）
 - **MiniMax**
 - **智谱AI**（GLM 系列模型）
+- **OpenRouter**（统一访问多种模型）
 - **Cloudflare Workers AI**（众多开源模型）
 
 ### OpenAI 兼容端点（自托管/本地）
@@ -164,6 +165,7 @@ docker-compose up -d
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **智谱AI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (统一访问多种模型): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **创意工具：**

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -63,6 +63,7 @@ Chibi 在單一對話中支援多個提供商。可新增單一金鑰或多個�
 - **月之暗面**（Moonshot AI）
 - **MiniMax**
 - **智譜AI**（GLM 系列模型）
+- **OpenRouter**（統一存取多種模型）
 - **Cloudflare Workers AI**（多個開源模型）
 
 ### OpenAI 相容端點（自託管 / 本機）
@@ -164,6 +165,7 @@ docker-compose up -d
 - **Moonshot** (Kimi): [platform.moonshot.cn](https://platform.moonshot.cn/)
 - **MiniMax** (Voice, MiniMax-M2.x): [minimax.io](https://www.minimax.io)
 - **智譜AI** (GLM, CogView): [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **OpenRouter** (統一存取多種模型): [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Cloudflare Workers AI**: [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 
 **創意工具：**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chibi-bot"
-version = "1.9.0"
+version = "1.10.0"
 description = "Your Digital Companion. Self-hosted Telegram bot orchestrating multiple AI providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Alibaba, MiniMax) with autonomous agent capabilities, MCP integrations, and async task execution. Not a tool. A partner."
 authors = ["Sergei Nagaev <nagaev.sv@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Added
- **Custom agent role/persona (`LLM_ROLE`)**: operator-assignable free-form persona that shapes the assistant's tone, focus, and scope while remaining subordinate to safety, honesty, privacy, and hard-rule invariants.
- **`AGENTS.md` / `CLAUDE.md` convention**: the assistant now looks for and reads project guidance files before working with code (applies to both the main agent and sub-agents).
- **Group chat shared context**: in group chats, the bot maintains a single shared conversation context common to all channel members, rather than per-user isolation.

### Changed
- **Sub-agent prompt**: filesystem & operations rules are now included only when filesystem access is enabled, reducing prompt size otherwise.

### Fixed
- **Command moderation**: added a plain-text JSON verdict fallback for models that don't honor forced tool calls (e.g. MiniMax M2.7/M3 on the Anthropic-compatible API), and fixed a crash when no tool call was returned.
