### PR TITLE
Fix: Fixed 'reset' and 'stop' commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-10
+
+### Fixed
+-  The `/reset` and `/stop` commands now terminate not all user-related processes, but only those launched from the same thread where the command is applied.
+-  A bug where changing the model in a group chat would change it not for the group chat, but for the user's private chat.
+
+
 ## [1.10.0] - 2026-06-07
 
 ### Added

--- a/chibi/runners/telegram.py
+++ b/chibi/runners/telegram.py
@@ -51,7 +51,6 @@ from chibi.utils.telegram import (
     current_user_action,
     get_telegram_chat,
     get_telegram_message,
-    get_telegram_user,
     get_user_context,
     set_user_action,
     set_user_context,
@@ -140,6 +139,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_drop_thread(interface=interface, args=args),
             user_id=interface.storage_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -157,6 +157,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_new_thread(interface=interface, args=args),
             user_id=interface.storage_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -174,6 +175,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_clone_thread(interface=interface, args=args),
             user_id=interface.storage_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -185,6 +187,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_provider_api_key_set(provider_name=provider_name, interface=interface),
             user_id=interface.user_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -198,7 +201,8 @@ class ChibiBot:
             interface = TelegramInterface(update=update, context=context)
             task_manager.run_task(
                 coro=handle_image_generation(prompt=prompt, interface=interface),
-                user_id=interface.user_id,  # Keep user_id: image quotas are per-user, not per-chat
+                user_id=interface.storage_id,
+                thread_id=interface.thread_id,
             )
             return None
 
@@ -257,6 +261,7 @@ class ChibiBot:
             task_manager.run_task(
                 coro=handle_user_prompt(interface=interface),
                 user_id=interface.storage_id,
+                thread_id=interface.thread_id,
             )
         return None
 
@@ -273,6 +278,7 @@ class ChibiBot:
             task_manager.run_task(
                 coro=handle_user_prompt(interface=interface),
                 user_id=interface.storage_id,
+                thread_id=interface.thread_id,
             )
             return None
 
@@ -289,7 +295,8 @@ class ChibiBot:
             set_user_action(context=context, action=UserAction.NONE)
             task_manager.run_task(
                 coro=handle_image_generation(prompt=prompt, interface=interface),
-                user_id=interface.user_id,  # Keep user_id: image quotas are per-user, not per-chat
+                user_id=interface.storage_id,
+                thread_id=interface.thread_id,
             )
             return None
 
@@ -304,6 +311,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_user_prompt(interface=interface),
             user_id=interface.storage_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -313,6 +321,7 @@ class ChibiBot:
         task_manager.run_task(
             coro=handle_user_prompt(interface=interface),
             user_id=interface.storage_id,
+            thread_id=interface.thread_id,
         )
         return None
 
@@ -419,11 +428,12 @@ class ChibiBot:
     @check_user_allowance
     async def show_llm_models_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         telegram_message = get_telegram_message(update=update)
+        telegram_interface = TelegramInterface(update=update, context=context)
 
         available_models = await handle_available_model_options(
-            user_id=get_telegram_user(update=update).id,
+            user_id=telegram_interface.storage_id,
             image_generation=False,
-            interface=TelegramInterface(update=update, context=context),
+            interface=telegram_interface,
         )
 
         active_model = get_user_context(context=context, key=UserContext.ACTIVE_MODEL, expected_type=str)
@@ -446,10 +456,9 @@ class ChibiBot:
     @check_user_allowance
     async def show_image_models_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         telegram_message = get_telegram_message(update=update)
+        telegram_interface = TelegramInterface(update=update, context=context)
         available_models = await handle_available_model_options(
-            user_id=get_telegram_user(update=update).id,
-            image_generation=True,
-            interface=TelegramInterface(update=update, context=context),
+            user_id=telegram_interface.storage_id, image_generation=True, interface=telegram_interface
         )
 
         active_model = get_user_context(context=context, key=UserContext.ACTIVE_IMAGE_MODEL, expected_type=str)
@@ -569,7 +578,8 @@ class ChibiBot:
                 model=model,
                 query=query,
             ),
-            user_id=telegram_interface.user_id,
+            user_id=telegram_interface.storage_id,
+            thread_id=telegram_interface.thread_id,
         )
 
         set_user_action(context=context, action=UserAction.NONE)
@@ -781,7 +791,7 @@ class ChibiBot:
             )
         )
 
-        # app.add_error_handler(self.error_handler)
+        app.add_error_handler(self.error_handler)
         if application_settings.heartbeat_url:
             if not app.job_queue:
                 logger.error("Could not launch heartbeat beacon: application job queue was shut down or never started.")

--- a/chibi/runners/terminal.py
+++ b/chibi/runners/terminal.py
@@ -156,7 +156,7 @@ class TerminalRunner:
             await handle_image_generation(prompt=prompt, interface=self.interface)
         except (KeyboardInterrupt, asyncio.CancelledError):
             console.print("\n[yellow]Image generation interrupted.[/yellow]")
-            task_manager.kill_all_user_tasks(user_id=self.user_id)
+            task_manager.kill_all_user_tasks(user_id=self.user_id, thread_id=0)
         except BaseException as e:
             console.print(f"\n[red]Error generating image: {e}[/red]")
             logger.exception("Image generation error")
@@ -240,7 +240,7 @@ class TerminalRunner:
             await handle_user_prompt(interface=self.interface)
         except (KeyboardInterrupt, asyncio.CancelledError):
             console.print("\n[yellow]Operation interrupted.[/yellow]")
-            task_manager.kill_all_user_tasks(user_id=self.user_id)
+            task_manager.kill_all_user_tasks(user_id=self.user_id, thread_id=0)
         except BaseException as e:
             console.print(f"\n[red]Error: {e}[/red]")
             logger.exception("Error processing message")

--- a/chibi/services/bot.py
+++ b/chibi/services/bot.py
@@ -1,3 +1,5 @@
+import time
+
 from loguru import logger
 from telegram import (
     CallbackQuery,
@@ -100,6 +102,7 @@ async def handle_tool_response(tool_response: ToolResponseSchema, interface: Use
 
 @handle_gpt_exceptions
 async def handle_user_prompt(interface: UserInterface) -> None:
+    time_start = time.time()
     text_prompt = await interface.get_text_prompt()
     voice_prompt = await interface.get_voice_prompt()
     caption_prompt = await interface.get_caption()
@@ -147,10 +150,11 @@ async def handle_user_prompt(interface: UserInterface) -> None:
         except Exception as e:
             logger.error(f"{interface.user_data}: Couldn't set message reaction due to exception: {e}")
         return None
-
+    time_end = time.time()
+    completion_time = time_end - time_start
     logger.info(
         f"{interface.user_data} got {chat_response.provider} ({chat_response.model}) answer in "
-        f"the {interface.chat_data}. {logged_answer} {usage_message}"
+        f"the {interface.chat_data}. {logged_answer} {usage_message} [{'%.2f' % completion_time}s]"
     )
     await interface.send_message(message=chat_response.answer)
     history_is_summarized = await check_history_and_summarize(
@@ -165,14 +169,14 @@ async def handle_reset(interface: UserInterface) -> None:
     logger.info(f"{interface.user_data}: conversation history reset.")
 
     await reset_chat_history(storage_id=interface.storage_id, thread_id=interface.thread_id)
-    task_manager.kill_all_user_tasks(user_id=interface.user_id)
+    task_manager.kill_all_user_tasks(user_id=interface.storage_id, thread_id=interface.thread_id)
     await interface.send_message(message="Done!", reply=False)
 
 
 async def handle_stop(interface: UserInterface) -> None:
     logger.info(f"{interface.user_data}: stopping everything...")
 
-    task_manager.kill_all_user_tasks(user_id=interface.user_id)
+    task_manager.kill_all_user_tasks(user_id=interface.storage_id, thread_id=interface.thread_id)
     await interface.send_message(message="Everything stopped.", reply=False)
 
 

--- a/chibi/services/metrics.py
+++ b/chibi/services/metrics.py
@@ -52,3 +52,4 @@ class MetricsService:
             model=model,
         )
         task_manager.run_task(coro=cls._send_to_influx(metric=metric, tags=tags), user_id=-1)
+        return None

--- a/chibi/services/providers/tools/tool.py
+++ b/chibi/services/providers/tools/tool.py
@@ -117,7 +117,7 @@ class ChibiTool:
 
         coro = cls._get_and_send_tool_call_result(*args, **kwargs)
         user_id = kwargs.get("user_id", -1)
-        task_manager.run_task(coro=coro, user_id=user_id)
+        task_manager.run_task(coro=coro, user_id=user_id, thread_id=interface.thread_id if interface else 0)
         return ToolResponseSchema(
             tool_name=cls.name,
             status="tool is running in background",

--- a/chibi/services/task_manager.py
+++ b/chibi/services/task_manager.py
@@ -10,8 +10,8 @@ class BackgroundTaskManager(metaclass=SingletonMeta):
     def __init__(self) -> None:
         """Initialize the task manager."""
         if not hasattr(self, "_tasks"):
-            self._tasks: dict[int, set[asyncio.Task]] = {}
-            self._task_to_user_id: dict[asyncio.Task, int] = {}
+            self._tasks: dict[str, set[asyncio.Task]] = {}
+            self._task_to_user_id: dict[asyncio.Task, str] = {}
             self._shutting_down: bool = False
 
     async def _wrap_with_timeout(self, coro: Coroutine[Any, Any, Any], timeout: float) -> Any:
@@ -29,14 +29,27 @@ class BackgroundTaskManager(metaclass=SingletonMeta):
             logger.warning(f"Background task timed out after {timeout}s")
             raise
 
+    def _get_task_id(self, user_id: int, thread_id: int) -> str:
+        """Get the task id for a user and thread.
+
+        Args:
+            user_id: The user id.
+            thread_id: The thread id.
+
+        Returns:
+            Task id.
+        """
+        return f"{user_id}-{thread_id}"
+
     def run_task(
-        self, coro: Coroutine[Any, Any, Any], user_id: int, timeout: float | None = None
+        self, coro: Coroutine[Any, Any, Any], user_id: int, thread_id: int = 0, timeout: float | None = None
     ) -> asyncio.Task | None:
         """Schedule a coroutine to run in the background.
 
         Args:
             coro: the coroutine to run
             user_id: the user id to link the task with
+            thread_id: the thread id to link the task with
             timeout: optional timeout in seconds. If the task doesn't complete
                      within this time, it will be cancelled with TimeoutError
         """
@@ -45,17 +58,19 @@ class BackgroundTaskManager(metaclass=SingletonMeta):
             coro.close()
             return None
 
+        task_id = self._get_task_id(user_id=user_id, thread_id=thread_id)
+
         # Wrap with timeout if specified
         if timeout is not None:
             coro = self._wrap_with_timeout(coro, timeout)
         logger.info(f"Starting background task {coro.__name__} for user {user_id}...")
         task = asyncio.create_task(coro)
-        if self._tasks.get(user_id):
-            self._tasks[user_id].add(task)
+        if self._tasks.get(task_id):
+            self._tasks[task_id].add(task)
         else:
-            self._tasks[user_id] = {task}
+            self._tasks[task_id] = {task}
 
-        self._task_to_user_id[task] = user_id
+        self._task_to_user_id[task] = task_id
         task.add_done_callback(self._discard_task)
         return task
 
@@ -99,9 +114,10 @@ class BackgroundTaskManager(metaclass=SingletonMeta):
                 task.cancel()
             logger.info(f"Cancelled {len(remaining)} remaining tasks.")
 
-    def kill_all_user_tasks(self, user_id: int) -> None:
-        logger.info(f"Killing all tasks for user {user_id}...")
-        user_tasks = self._tasks.pop(user_id, None)
+    def kill_all_user_tasks(self, user_id: int, thread_id: int) -> None:
+        logger.info(f"Killing all tasks for user {user_id} in thread {thread_id}...")
+        task_id = self._get_task_id(user_id=user_id, thread_id=thread_id)
+        user_tasks = self._tasks.pop(task_id, None)
         if not user_tasks:
             logger.info(f"Nothing to kill there: the user {user_id} has no running tasks.")
             return None

--- a/chibi/utils/telegram.py
+++ b/chibi/utils/telegram.py
@@ -527,7 +527,6 @@ def user_interacts_with_bot(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         True if the user is interacting with the bot, False otherwise.
     """
     telegram_message = get_telegram_message(update=update)
-    print(telegram_message.text)
     # Check entities for mentions (e.g. @botname in Telegram UI)
     if telegram_message.entities:
         for entity in telegram_message.entities:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chibi-bot"
-version = "1.10.0"
+version = "1.11.0"
 description = "Your Digital Companion. Self-hosted Telegram bot orchestrating multiple AI providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Alibaba, MiniMax) with autonomous agent capabilities, MCP integrations, and async task execution. Not a tool. A partner."
 authors = ["Sergei Nagaev <nagaev.sv@gmail.com>"]
 license = "MIT"

--- a/tests/services/test_task_manager.py
+++ b/tests/services/test_task_manager.py
@@ -29,14 +29,14 @@ async def test_run_task_adds_task(manager):
     manager.run_task(dummy_task(), user_id=1)
 
     assert len(manager._tasks) == 1
-    assert 1 in manager._tasks
-    assert len(manager._tasks[1]) == 1
+    assert "1-0" in manager._tasks
+    assert len(manager._tasks["1-0"]) == 1
 
     # Wait for task to complete
     await asyncio.sleep(0.02)
 
     # Task should be removed from set
-    assert len(manager._tasks[1]) == 0
+    assert len(manager._tasks["1-0"]) == 0
 
 
 @pytest.mark.asyncio
@@ -46,8 +46,8 @@ async def test_run_task_creates_user_set(manager):
 
     manager.run_task(dummy_task(), user_id=42)
 
-    assert 42 in manager._tasks
-    assert isinstance(manager._tasks[42], set)
+    assert "42-0" in manager._tasks
+    assert isinstance(manager._tasks["42-0"], set)
 
 
 @pytest.mark.asyncio
@@ -57,7 +57,7 @@ async def test_run_task_maps_task_to_user_id(manager):
 
     task = manager.run_task(dummy_task(), user_id=123)
 
-    assert manager._task_to_user_id[task] == 123
+    assert manager._task_to_user_id[task] == "123-0"
 
     await asyncio.sleep(0.02)
 
@@ -72,8 +72,8 @@ async def test_multiple_users(manager):
     manager.run_task(dummy_task(), user_id=2)
 
     assert len(manager._tasks) == 2
-    assert len(manager._tasks[1]) == 2
-    assert len(manager._tasks[2]) == 1
+    assert len(manager._tasks["1-0"]) == 2
+    assert len(manager._tasks["2-0"]) == 1
 
     await asyncio.sleep(0.02)
 
@@ -90,7 +90,7 @@ async def test_task_exception_handling(manager):
     await asyncio.sleep(0.01)
 
     # Task should be removed even if failed
-    assert len(manager._tasks[1]) == 0
+    assert len(manager._tasks["1-0"]) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

### Fixed
-  The `/reset` and `/stop` commands now terminate not all user-related processes, but only those launched from the same thread where the command is applied.
-  A bug where changing the model in a group chat would change it not for the group chat, but for the user's private chat.
