### PR TITLE
Feat: Background message frames for IDE stdio transport

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-09-02
+
+### Added
+- **Background message delivery (IDE stdio):** background tool completions (e.g. delegation results) are no longer silently lost when the original request has already finished. Clients that declare `capabilities.background_messages: true` in the `initialize` handshake receive out-of-band `{type: "message", thread_id, content, model?, provider?}` frames routed by thread; `model`/`provider` are set when the producing response carries them. Emission failures are logged and the frame is dropped. Clients that do not declare the capability are unaffected; no protocol_version bump.
+
 ## [1.14.0] - 2026-08-31
 
 ### Added
@@ -636,7 +641,8 @@ applied.
 - Flake8 and Mypy setups.
 - GitHub Action for linters.
 
-[Unreleased]: https://github.com/s-nagaev/chibi/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/s-nagaev/chibi/compare/v1.14.1...HEAD
+[1.14.1]: https://github.com/s-nagaev/chibi/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/s-nagaev/chibi/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/s-nagaev/chibi/compare/v1.13.1b1...v1.13.1
 [1.13.1b1]: https://github.com/s-nagaev/chibi/compare/v1.13.1-beta...v1.13.1b1

--- a/chibi/runners/ide_transport.py
+++ b/chibi/runners/ide_transport.py
@@ -83,7 +83,14 @@ class IDEInterface(UserInterface, EditorContextProvider):
 
     uses_uploaded_file_storage = False
 
-    def __init__(self, thread_id: int, prompt: str, context: dict[str, Any], emit: Callable[[str], Any]) -> None:
+    def __init__(
+        self,
+        thread_id: int,
+        prompt: str,
+        context: dict[str, Any],
+        emit: Callable[[str], Any],
+        background_emit: Callable[[int, str, str | None, str | None], Any] | None = None,
+    ) -> None:
         """Initialize an IDE request interface.
 
         Args:
@@ -91,15 +98,29 @@ class IDEInterface(UserInterface, EditorContextProvider):
             prompt: User prompt for this request.
             context: Editor context supplied by the client.
             emit: Callback receiving assistant text responses.
+            background_emit: Optional session-level callback delivering
+                assistant text as out-of-band background message frames
+                after the owning request has finished.
         """
         self._thread_id = thread_id
         self._prompt = prompt
         self._context = context
         self._emit = emit
+        self._background_emit = background_emit
+        self._closed = False
         self.response_model: str | None = None
         self.response_provider: str | None = None
         self.error_code: str | None = None
         self.error_message: str | None = None
+
+    def mark_closed(self) -> None:
+        """Flag the owning request as finished.
+
+        After this, assistant text delivered by background tool tasks is
+        routed to the out-of-band background emitter instead of the dead
+        request's response buffer.
+        """
+        self._closed = True
 
     @property
     def editor_context(self) -> dict[str, Any] | None:
@@ -191,6 +212,35 @@ class IDEInterface(UserInterface, EditorContextProvider):
     async def delete_last_user_message(self) -> None:
         """Ignore message deletion on stdio."""
 
+    async def send_tool_answer(self, content: str, model: str | None = None, provider: str | None = None) -> None:
+        """Deliver an answer produced by a background tool task.
+
+        While the owning request is still open, the text is appended to the
+        request's response buffer exactly as before. Once the request has
+        finished, the text is routed to the session-level background emitter
+        so it reaches the client as a ``message`` frame instead of being
+        silently lost.
+
+        Args:
+            content: Assistant text being delivered.
+            model: Model that produced the answer, when known.
+            provider: Provider that produced the answer, when known.
+        """
+        if self._closed:
+            if self._background_emit is None:
+                logger.debug(
+                    "Dropping background tool answer for thread {}: client did not declare background_messages",
+                    self._thread_id,
+                )
+                return
+            result = self._background_emit(self._thread_id, content, model, provider)
+            if inspect.isawaitable(result):
+                await result
+            return
+        result = self._emit(content)
+        if inspect.isawaitable(result):
+            await result
+
     async def send_message(self, message: str, reply: bool = True, **kwargs: Any) -> None:
         """Emit assistant text through the request-local callback."""
         result = self._emit(message)
@@ -276,6 +326,7 @@ class IDEStdioRunner:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._thread_requests: dict[int, int] = {}
         self._active_clones: set[int] = set()
+        self._background_messages_enabled = False
         self.exit_code = 0
         self._stdout_lock = asyncio.Lock()
 
@@ -305,6 +356,32 @@ class IDEStdioRunner:
         await self._write(
             {"type": "error", "request_id": request_id, "code": _frontend_code(code), "message": message, **extra}
         )
+
+    async def _emit_background_message(
+        self, thread_id: int, content: str, model: str | None, provider: str | None
+    ) -> None:
+        """Write one out-of-band background message frame to stdout.
+
+        The frame shares the regular stdout write lock, so wire lines are
+        never interleaved. On a write failure the message is logged and
+        dropped: background delivery is best effort and there is no
+        request id to correlate an error frame to.
+
+        Args:
+            thread_id: Thread the background task was spawned from.
+            content: Assistant text being delivered.
+            model: Model that produced the answer, if known.
+            provider: Provider that produced the answer, if known.
+        """
+        frame: dict[str, Any] = {"type": "message", "thread_id": thread_id, "content": content}
+        if model is not None:
+            frame["model"] = model
+        if provider is not None:
+            frame["provider"] = provider
+        try:
+            await self._write(frame)
+        except Exception:
+            logger.exception("Failed to deliver a background message for thread {}", thread_id)
 
     async def emit_rate_limited(self, message: str, retry_after: int, request_id: str | None = None) -> None:
         """Emit a canonical rate-limited error frame with a retry hint.
@@ -439,7 +516,8 @@ class IDEStdioRunner:
         thread_id = message["thread_id"]
         prompt = message["prompt"].strip()
         responses: list[str] = []
-        interface = IDEInterface(thread_id, prompt, message, responses.append)
+        background_emit = self._emit_background_message if self._background_messages_enabled else None
+        interface = IDEInterface(thread_id, prompt, message, responses.append, background_emit=background_emit)
         await self._write({"type": "status", "request_id": request_id, "state": "running"})
         try:
             if prompt.startswith("/"):
@@ -530,6 +608,7 @@ class IDEStdioRunner:
                 cause=type(exc).__name__,
             )
         finally:
+            interface.mark_closed()
             self._tasks.pop(request_id, None)
             remaining = self._thread_requests.get(thread_id, 1) - 1
             if remaining <= 0:
@@ -563,6 +642,11 @@ class IDEStdioRunner:
                 raw_version = client.get("version")
                 self.client_name = raw_name if isinstance(raw_name, str) else None
                 self.client_version = raw_version if isinstance(raw_version, str) else None
+                raw_capabilities = message.get("capabilities")
+                capabilities = raw_capabilities if isinstance(raw_capabilities, dict) else {}
+                self._background_messages_enabled = capabilities.get("background_messages") is True
+                if self._background_messages_enabled:
+                    logger.debug("client declared the background_messages capability")
                 logger.info(
                     "client_handshake name={} version={} protocol_version={}",
                     self.client_name or "<unknown>",

--- a/chibi/services/bot.py
+++ b/chibi/services/bot.py
@@ -67,7 +67,9 @@ async def handle_tool_response(tool_response: ToolResponseSchema, interface: Use
         f"{interface.user_data} got {chat_response.provider} ({chat_response.model}) answer in "
         f"the {interface.chat_data}. {logged_answer} {usage_message}"
     )
-    await interface.send_message(message=chat_response.answer)
+    await interface.send_tool_answer(
+        content=chat_response.answer, model=chat_response.model, provider=chat_response.provider
+    )
 
 
 # async def handle_scheduled_event(

--- a/chibi/services/interface.py
+++ b/chibi/services/interface.py
@@ -165,6 +165,20 @@ class UserInterface(ABC):
         """
         raise NotImplementedError
 
+    async def send_tool_answer(self, content: str, model: str | None = None, provider: str | None = None) -> None:
+        """Delivers an answer produced by a background tool task.
+
+        The default delivery is a regular message. Interfaces with an
+        out-of-band background channel may override this to route the
+        answer differently once the originating request has finished.
+
+        Args:
+            content: The assistant text to deliver.
+            model: The model that produced the answer, when known.
+            provider: The provider that produced the answer, when known.
+        """
+        await self.send_message(message=content)
+
     async def send_audio(
         self,
         audio: bytes | str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chibi-bot"
-version = "1.14.0"
+version = "1.14.1"
 description = "Your Digital Companion. Self-hosted Telegram bot orchestrating multiple AI providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Alibaba, MiniMax) with autonomous agent capabilities, MCP integrations, and async task execution. Not a tool. A partner."
 authors = ["Sergei Nagaev <nagaev.sv@gmail.com>"]
 license = "MIT"

--- a/tests/runners/test_ide_background_messages.py
+++ b/tests/runners/test_ide_background_messages.py
@@ -108,17 +108,17 @@ def deliver_later(content: str, model: str | None = None, provider: str | None =
 
         task = asyncio.create_task(deliver())
         BACKGROUND_TASKS.append(task)
-        interface.background_task = task
         await interface.send_message("Foreground answer")
 
     return fake_prompt
 
 
-def initialize(capabilities: dict[str, Any] | None = None) -> dict[str, Any]:
+def initialize(capabilities: Any = None) -> dict[str, Any]:
     """Build an initialize message.
 
     Args:
-        capabilities: Optional client capabilities payload.
+        capabilities: Optional client capabilities payload. Non-object values
+            (for example a bare string) are allowed for malformed-input tests.
 
     Returns:
         A protocol initialize message.

--- a/tests/runners/test_ide_background_messages.py
+++ b/tests/runners/test_ide_background_messages.py
@@ -1,0 +1,339 @@
+"""Background message frame coverage for the IDE stdio transport."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import chibi.config  # noqa: F401
+from chibi.runners.ide_transport import COMMANDS, PROTOCOL_VERSION, IDEInterface, IDEStdioRunner
+from chibi.schemas.app import ChatResponseSchema
+from chibi.services.bot import handle_tool_response
+from chibi.services.providers.tools.schemas import ToolResponseSchema
+
+READY_FRAME: dict[str, Any] = {
+    "type": "ready",
+    "protocol_version": PROTOCOL_VERSION,
+    "server": {"name": "chibi", "version": "1.0.0"},
+    "capabilities": {"commands": COMMANDS},
+}
+
+BACKGROUND_TASKS: list[asyncio.Task[None]] = []
+
+
+class OutputRecorder:
+    """Capture protocol frames through an async callable."""
+
+    def __init__(self, fail_on_types: set[str] | None = None) -> None:
+        """Initialize empty captured output.
+
+        Args:
+            fail_on_types: Frame types whose writes must raise, simulating a broken stdout.
+        """
+        self.frames: list[dict[str, Any]] = []
+        self._fail_on_types = fail_on_types or set()
+
+    async def __call__(self, message: dict[str, Any]) -> None:
+        """Capture one protocol frame.
+
+        Args:
+            message: Emitted JSON-compatible protocol frame.
+        """
+        if message.get("type") in self._fail_on_types:
+            raise RuntimeError("stdout pipe is broken")
+        self.frames.append(message)
+
+
+def runner(fail_on_types: set[str] | None = None) -> tuple[IDEStdioRunner, list[dict[str, Any]]]:
+    """Create a runner with captured protocol output.
+
+    Args:
+        fail_on_types: Frame types whose writes must raise.
+
+    Returns:
+        The runner and its mutable captured-frame list.
+    """
+    instance = IDEStdioRunner()
+    recorder = OutputRecorder(fail_on_types=fail_on_types)
+    instance.__dict__["_write"] = recorder
+    return instance, recorder.frames
+
+
+async def wait_for_frame(output: list[dict[str, Any]], frame_type: str) -> dict[str, Any]:
+    """Wait until a frame of the given type is emitted and return it.
+
+    Args:
+        output: Captured frame list.
+        frame_type: Frame type to wait for.
+
+    Returns:
+        The first matching frame.
+    """
+    for _ in range(300):
+        for frame in output:
+            if frame.get("type") == frame_type:
+                return frame
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"Missing {frame_type} frame: {output}")
+
+
+async def wait_until_closed(interface: IDEInterface) -> None:
+    """Wait until the request owning the interface is finished."""
+    for _ in range(300):
+        if interface._closed:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Interface was never closed")
+
+
+def deliver_later(content: str, model: str | None = None, provider: str | None = None) -> Any:
+    """Build a fake prompt handler that delivers an answer after the request closes.
+
+    Args:
+        content: Background answer text.
+        model: Optional model name attached to the delivery.
+        provider: Optional provider name attached to the delivery.
+
+    Returns:
+        An async handler compatible with the patched ``handle_user_prompt``.
+    """
+
+    async def fake_prompt(interface: IDEInterface) -> None:
+        async def deliver() -> None:
+            await wait_until_closed(interface)
+            await interface.send_tool_answer(content, model=model, provider=provider)
+
+        task = asyncio.create_task(deliver())
+        BACKGROUND_TASKS.append(task)
+        interface.background_task = task
+        await interface.send_message("Foreground answer")
+
+    return fake_prompt
+
+
+def initialize(capabilities: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build an initialize message.
+
+    Args:
+        capabilities: Optional client capabilities payload.
+
+    Returns:
+        A protocol initialize message.
+    """
+    message: dict[str, Any] = {"type": "initialize", "protocol_version": PROTOCOL_VERSION}
+    if capabilities is not None:
+        message["capabilities"] = capabilities
+    return message
+
+
+async def run_request(instance: IDEStdioRunner, request_id: str, thread_id: int) -> None:
+    """Run one protocol request through the runner.
+
+    Args:
+        instance: Runner under test.
+        request_id: Request identifier.
+        thread_id: Thread identifier.
+    """
+    await instance._handle_message(
+        {
+            "type": "request",
+            "request_id": request_id,
+            "thread_id": thread_id,
+            "prompt": "hi",
+            "workspace_root": "/tmp",
+            "active_file": None,
+            "selection": None,
+            "cursor_position": None,
+            "language_id": None,
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+async def background_task_cleanup() -> Any:
+    """Await and clear spawned background tasks after each test."""
+    yield
+    tasks, BACKGROUND_TASKS[:] = BACKGROUND_TASKS[:], []
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+class TestHandshake:
+    """Handshake handling of the optional capabilities object."""
+
+    @pytest.mark.asyncio
+    async def test_background_messages_capability_is_stored(self) -> None:
+        """Declaring background_messages enables the session flag."""
+        instance, output = runner()
+
+        await instance._handle_message(initialize({"background_messages": True}))
+
+        assert instance._background_messages_enabled is True
+        assert output[0] == READY_FRAME
+
+    @pytest.mark.asyncio
+    async def test_ready_frame_unchanged_without_capabilities(self) -> None:
+        """Clients that never send capabilities get the standard ready frame."""
+        instance, output = runner()
+
+        await instance._handle_message(initialize())
+
+        assert instance._background_messages_enabled is False
+        assert output[0] == READY_FRAME
+
+    @pytest.mark.asyncio
+    async def test_malformed_capabilities_do_not_enable_emission(self) -> None:
+        """Non-object capabilities payloads keep emission off."""
+        instance, output = runner()
+
+        await instance._handle_message(initialize("not-an-object"))
+
+        assert instance._background_messages_enabled is False
+        assert output[0] == READY_FRAME
+
+
+class TestBackgroundMessageFrames:
+    """Emission of out-of-band message frames for background tool answers."""
+
+    @pytest.mark.asyncio
+    async def test_frame_emitted_with_thread_id_and_metadata(self) -> None:
+        """A background answer after request completion becomes a message frame."""
+        instance, output = runner()
+        with patch(
+            "chibi.runners.ide_transport.handle_user_prompt", deliver_later("Background answer", "gpt-x", "prov")
+        ):
+            await instance._handle_message(initialize({"background_messages": True}))
+            await run_request(instance, "r1", 42)
+            await wait_for_frame(output, "message")
+
+        frame = next(f for f in output if f.get("type") == "message")
+        assert frame == {
+            "type": "message",
+            "thread_id": 42,
+            "content": "Background answer",
+            "model": "gpt-x",
+            "provider": "prov",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_frame_without_capability(self) -> None:
+        """Clients that did not declare the capability never see message frames."""
+        instance, output = runner()
+        with patch("chibi.runners.ide_transport.handle_user_prompt", deliver_later("Background answer")):
+            await instance._handle_message(initialize())
+            await run_request(instance, "r1", 42)
+            await wait_for_frame(output, "result")
+
+        assert not any(f.get("type") == "message" for f in output)
+
+    @pytest.mark.asyncio
+    async def test_optional_fields_omitted_when_unknown(self) -> None:
+        """model and provider are dropped from the frame when not provided."""
+        instance, output = runner()
+        with patch("chibi.runners.ide_transport.handle_user_prompt", deliver_later("Background answer")):
+            await instance._handle_message(initialize({"background_messages": True}))
+            await run_request(instance, "r1", 7)
+            await wait_for_frame(output, "message")
+
+        frame = next(f for f in output if f.get("type") == "message")
+        assert frame == {"type": "message", "thread_id": 7, "content": "Background answer"}
+
+
+class TestRequestScopedContractUnchanged:
+    """Foreground request behavior stays identical while the capability is on."""
+
+    @pytest.mark.asyncio
+    async def test_foreground_answer_still_lands_in_result(self) -> None:
+        """The result frame still correlates the foreground answer by request_id."""
+        instance, output = runner()
+        with patch(
+            "chibi.runners.ide_transport.handle_user_prompt", deliver_later("Background answer", "gpt-x", "prov")
+        ):
+            await instance._handle_message(initialize({"background_messages": True}))
+            await run_request(instance, "r1", 42)
+            await wait_for_frame(output, "result")
+
+        result = next(f for f in output if f.get("type") == "result")
+        assert result == {"type": "result", "request_id": "r1", "content": "Foreground answer"}
+        statuses = [f for f in output if f.get("type") == "status"]
+        assert statuses[0] == {"type": "status", "request_id": "r1", "state": "running"}
+
+
+class TestEmissionFailureResilience:
+    """A broken stdout during emission must not kill the background task."""
+
+    @pytest.mark.asyncio
+    async def test_write_failure_is_dropped_without_raising(self) -> None:
+        """A failing message frame write raises nothing at the delivery site."""
+        instance, _output = runner(fail_on_types={"message"})
+        responses: list[str] = []
+
+        async def emit_background(thread_id: int, content: str, model: str | None, provider: str | None) -> None:
+            await instance._emit_background_message(thread_id, content, model, provider)
+
+        interface = IDEInterface(3, "p", {}, responses.append, background_emit=emit_background)
+        interface.mark_closed()
+
+        await interface.send_tool_answer("Answer that will be dropped", model="m", provider="p")
+
+        assert responses == []
+
+    @pytest.mark.asyncio
+    async def test_background_task_survives_write_failure(self) -> None:
+        """The background delivery task completes even when the write fails."""
+        instance, output = runner(fail_on_types={"message"})
+        with patch("chibi.runners.ide_transport.handle_user_prompt", deliver_later("Doomed answer", "m", "p")):
+            await instance._handle_message(initialize({"background_messages": True}))
+            await run_request(instance, "r1", 42)
+            await wait_for_frame(output, "result")
+            for task in list(BACKGROUND_TASKS):
+                await asyncio.gather(task)
+
+        assert not any(f.get("type") == "message" for f in output)
+
+
+class TestHandleToolResponsePlumbing:
+    """handle_tool_response routes answers through send_tool_answer with metadata."""
+
+    @pytest.mark.asyncio
+    async def test_closed_interface_emits_frame_with_model_and_provider(self) -> None:
+        """A closed IDE interface delivers the tool answer as a background frame."""
+        instance, output = runner()
+        emitted: list[tuple[int, str, str | None, str | None]] = []
+
+        async def emit_background(thread_id: int, content: str, model: str | None, provider: str | None) -> None:
+            emitted.append((thread_id, content, model, provider))
+            await instance._emit_background_message(thread_id, content, model, provider)
+
+        interface = IDEInterface(11, "p", {}, lambda _: None, background_emit=emit_background)
+        interface.mark_closed()
+        chat_response = ChatResponseSchema(answer="Tool answer", provider="prov", model="m", usage=None)
+
+        with patch("chibi.services.bot.get_llm_chat_completion_answer", new=AsyncMock(return_value=chat_response)):
+            await handle_tool_response(
+                tool_response=ToolResponseSchema(tool_name="t", status="ok", result="ok"), interface=interface
+            )
+
+        assert output == [
+            {"type": "message", "thread_id": 11, "content": "Tool answer", "model": "m", "provider": "prov"}
+        ]
+        assert emitted == [(11, "Tool answer", "m", "prov")]
+
+    @pytest.mark.asyncio
+    async def test_open_interface_appends_to_request_responses(self) -> None:
+        """An open request still collects the tool answer in its response buffer."""
+        responses: list[str] = []
+        interface = IDEInterface(11, "p", {}, responses.append)
+        chat_response = ChatResponseSchema(answer="Tool answer", provider="prov", model="m", usage=None)
+
+        with patch("chibi.services.bot.get_llm_chat_completion_answer", new=AsyncMock(return_value=chat_response)):
+            await handle_tool_response(
+                tool_response=ToolResponseSchema(tool_name="t", status="ok", result="ok"), interface=interface
+            )
+
+        assert responses == ["Tool answer"]


### PR DESCRIPTION
### Added
- **Background message delivery (IDE stdio):** background tool completions (e.g. delegation results) are no longer silently lost when the original request has already finished. 